### PR TITLE
Global events file and adjustments to Dynamic Yield

### DIFF
--- a/events.ts
+++ b/events.ts
@@ -25,14 +25,14 @@
     reportToDynamicYield();
   }
 
-  waitForeverFor(selector, '.Main', (element) => {
+  waitFor(selector, '.Main', (element) => {
     if (existWithContent(element)) {
       addIdentifierClasses(element);
       reportToDynamicYield();
     }
   });
 
-  function waitForeverFor(selector, element, callback) {
+  function waitFor(selector, element, callback) {
     console.debug('<experiment> Wait for selector', selector);
 
     // If not an element
@@ -53,8 +53,9 @@
           let selectorElement;
           if (node.matches(selector)) {
             console.debug('<experiment> Selector matches', selector);
-            console.debug('<experiment> callback', node);
+            observer.disconnect();
 
+            console.debug('<experiment> callback', node);
             callback(node);
           } else if ((selectorElement = node.querySelector(selector))) {
             console.debug('<experiment> Selector exist in node', selector);

--- a/events.ts
+++ b/events.ts
@@ -76,7 +76,7 @@ const cover = {
     '.Notice.Notice--info.Notice--animated.Notice--center',
     '.Main',
     (element) => {
-      addIdentifierClasses(element, 'T35');
+      addIdentifierClasses(element, 'T66');
       eventToDynamicYield();
     },
     {
@@ -90,7 +90,7 @@ const cover = {
     '[data-test="cncheader-chagedeliverymethodbutton"]',
     '#portal',
     (element) => {
-      addIdentifierClasses(element, 'T32');
+      addIdentifierClasses(element, 'T67');
       eventToDynamicYield();
     },
     {

--- a/events.ts
+++ b/events.ts
@@ -14,13 +14,21 @@
     element.classList.add('Experiment', 'T35', 'variant1-delete');
   };
 
+  const reportToDynamicYield = () => {
+    DY.API('event', {
+      name: 'test',
+    });
+  };
+
   if (existWithContent(element)) {
     addIdentifierClasses(element);
+    reportToDynamicYield();
   }
 
   waitForeverFor(selector, '.Main', (element) => {
     if (existWithContent(element)) {
       addIdentifierClasses(element);
+      reportToDynamicYield();
     }
   });
 

--- a/events.ts
+++ b/events.ts
@@ -25,14 +25,16 @@
     reportToDynamicYield();
   }
 
-  waitFor(selector, '.Main', (element) => {
+  cover.waitFor(selector, '.Main', (element) => {
     if (existWithContent(element)) {
       addIdentifierClasses(element);
       reportToDynamicYield();
     }
   });
+})();
 
-  function waitFor(selector, element, callback) {
+const cover = {
+  waitFor: (selector, element, callback) => {
     console.debug('<experiment> Wait for selector', selector);
 
     // If not an element
@@ -73,5 +75,5 @@
       childList: true,
       subtree: true,
     });
-  }
-})();
+  },
+};

--- a/events.ts
+++ b/events.ts
@@ -90,6 +90,6 @@ const cover = {
       addIdentifierClasses(element);
       eventToDynamicYield();
     },
-    { disconnect: false, content: content }
+    { init: true, disconnect: false, content: content }
   );
 })();

--- a/events.ts
+++ b/events.ts
@@ -62,19 +62,8 @@ const cover = {
 };
 
 (() => {
-  const selector = '.Notice.Notice--info.Notice--animated.Notice--center';
-  const content = 'Nu visas varor för: Hemleverans i StockholmÄndra';
-  const element = document.querySelector(selector);
-
-  const existWithContent = (element) => {
-    if (element?.textContent == content) {
-      return true;
-    }
-    return false;
-  };
-
-  const addIdentifierClasses = (element) => {
-    element.classList.add('Experiment', 'T35');
+  const addIdentifierClasses = (element, id) => {
+    element.classList.add('Experiment', id);
   };
 
   const eventToDynamicYield = () => {
@@ -84,12 +73,28 @@ const cover = {
   };
 
   cover.waitFor(
-    selector,
+    '.Notice.Notice--info.Notice--animated.Notice--center',
     '.Main',
     (element) => {
-      addIdentifierClasses(element);
+      addIdentifierClasses(element, 'T35');
       eventToDynamicYield();
     },
-    { init: true, disconnect: false, content: content }
+    {
+      init: true,
+      disconnect: false,
+      content: 'Nu visas varor för: Hemleverans i StockholmÄndra',
+    }
+  );
+
+  cover.waitFor(
+    '[data-test="cncheader-chagedeliverymethodbutton"]',
+    '#portal',
+    (element) => {
+      addIdentifierClasses(element, 'T32');
+      eventToDynamicYield();
+    },
+    {
+      disconnect: false,
+    }
   );
 })();

--- a/events.ts
+++ b/events.ts
@@ -11,7 +11,7 @@
   };
 
   const addIdentifierClasses = (element) => {
-    element.classList.add('Experiment', 'T35', 'variant1-delete');
+    element.classList.add('Experiment', 'T35');
   };
 
   const reportToDynamicYield = () => {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "babel": "babel . --ignore 'node_modules' --extensions '.ts' --watch --out-dir .",
-    "build": "babel events.ts --ignore 'node_modules' --extensions '.ts' --out-dir public"
+    "build": "babel . --ignore 'node_modules' --extensions '.ts' --out-dir public/."
   },
   "repository": {
     "type": "git",

--- a/t32/variant1.ts
+++ b/t32/variant1.ts
@@ -1,0 +1,11 @@
+(function run() {
+  cover.waitFor(
+    '.T32',
+    '#portal',
+    (element) => {
+      element.remove();
+      run();
+    },
+    { init: true, disconnect: false }
+  );
+})();

--- a/t35/variant1.ts
+++ b/t35/variant1.ts
@@ -1,0 +1,13 @@
+(function run() {
+  console.debug('<experiment> Wait for T35');
+  cover.waitFor(
+    '.T35',
+    '.Main',
+    (element) => {
+      console.debug('<experiment> Remove T35');
+      element.remove();
+      run();
+    },
+    { init: true, disconnect: false }
+  );
+})();

--- a/t66/variant1.ts
+++ b/t66/variant1.ts
@@ -1,10 +1,10 @@
 (function run() {
-  console.debug('<experiment> Wait for T35');
+  console.debug('<experiment> Wait for T66');
   cover.waitFor(
-    '.T35',
+    '.T66',
     '.Main',
     (element) => {
-      console.debug('<experiment> Remove T35');
+      console.debug('<experiment> Remove T66');
       element.remove();
       run();
     },

--- a/t67/variant1.ts
+++ b/t67/variant1.ts
@@ -1,6 +1,6 @@
 (function run() {
   cover.waitFor(
-    '.T32',
+    '.T67',
     '#portal',
     (element) => {
       element.remove();


### PR DESCRIPTION
This experiment is activated by Dynamic Yield, and used on cooptest2.coop.se, hence using "event: test" as temporary trigger. The ID "T35" will also be updated.

Instead of cut and pasting code into Tag Manager and Optimize, we'll try to create combine files and host them on our server. We've removed all old experiments and created a shared "waitFor" function in "cover.waitFor()". The events.ts will be kept updated and individual test folders will be removed when not used.

We're using automatic deploy from GitHub, using Netlify and building JavaScript files with Babel (target = "ie 11"). We're also using "pull request" in GitHub. Please add comments directly to GitHub.